### PR TITLE
Skipped empty section pointcloud's ground estimation proposals

### DIFF
--- a/include/patchwork/patchwork.hpp
+++ b/include/patchwork/patchwork.hpp
@@ -443,7 +443,7 @@ void PatchWork<PointT>::estimate_sensor_height(pcl::PointCloud<PointT> cloud_in)
     vector<double> planarities;
     for (int i = 0; i < num_sectors_for_ATAT_; ++i) {
 
-        if(ring_for_ATAT[i].empty()){ continue; }
+        if(ring_for_ATAT[i].size() < num_min_pts_ ){ continue; }
 
         pcl::PointCloud<PointT> dummy_est_ground;
         pcl::PointCloud<PointT> dummy_est_non_ground;

--- a/include/patchwork/patchwork.hpp
+++ b/include/patchwork/patchwork.hpp
@@ -442,6 +442,9 @@ void PatchWork<PointT>::estimate_sensor_height(pcl::PointCloud<PointT> cloud_in)
     vector<double> linearities;
     vector<double> planarities;
     for (int i = 0; i < num_sectors_for_ATAT_; ++i) {
+
+        if(ring_for_ATAT[i].empty()){ continue; }
+
         pcl::PointCloud<PointT> dummy_est_ground;
         pcl::PointCloud<PointT> dummy_est_non_ground;
         extract_piecewiseground(0, ring_for_ATAT[i], dummy_est_ground, dummy_est_non_ground, false);


### PR DESCRIPTION
Hello,

I noticed that we are letting empty sections and calculate the singular values on them which will lead to `nan` values.

https://github.com/LimHyungTae/patchwork/blob/4b4f2118f706e339c1ed23b5710bc732d8c7c54d/include/patchwork/patchwork.hpp#L444-L462

1. Here is the output of Size of the pointcloud for ring(section), singular values and Linearity/Planarity results in original code:
   1. You can clearly see that from the last ring(section), even we don't have any points in section, if there were calculations done in step before; the values of respective features will copied from the last section. Which will definetely effect the correctness of the height calculation.
   2. Here is the subset of the wrong output:
```
patchwork_ground_seg: SizeOfRing: 33
patchwork_ground_seg: * Singular Values: 0.0368877, 0.00435487, 1.95469e-05
patchwork_ground_seg: * Linearity: 0.881942
patchwork_ground_seg: * Planarity: 0.117528
patchwork_ground_seg: SizeOfRing: 0
patchwork_ground_seg: * Singular Values: 0.0368877, 0.00435487, 1.95469e-05
patchwork_ground_seg: * Linearity: 0.881942
patchwork_ground_seg: * Planarity: 0.117528
```
<details>

```
patchwork_ground_seg: SizeOfRing: 0
patchwork_ground_seg: * Singular Values: 0, 0, 0
patchwork_ground_seg: * Linearity: -nan
patchwork_ground_seg: * Planarity: -nan
patchwork_ground_seg: SizeOfRing: 143
patchwork_ground_seg: * Singular Values: 0.109471, 0.0290639, 3.99177e-05
patchwork_ground_seg: * Linearity: 0.734506
patchwork_ground_seg: * Planarity: 0.26513
patchwork_ground_seg: SizeOfRing: 279
patchwork_ground_seg: * Singular Values: 0.294544, 0.0965589, 3.21574e-05
patchwork_ground_seg: * Linearity: 0.672175
patchwork_ground_seg: * Planarity: 0.327716
patchwork_ground_seg: SizeOfRing: 323
patchwork_ground_seg: * Singular Values: 0.462427, 0.120994, 4.09155e-05
patchwork_ground_seg: * Linearity: 0.738349
patchwork_ground_seg: * Planarity: 0.261562
patchwork_ground_seg: SizeOfRing: 493
patchwork_ground_seg: * Singular Values: 0.422977, 0.111352, 4.06778e-05
patchwork_ground_seg: * Linearity: 0.736741
patchwork_ground_seg: * Planarity: 0.263163
patchwork_ground_seg: SizeOfRing: 478
patchwork_ground_seg: * Singular Values: 0.265785, 0.124776, 5.04178e-05
patchwork_ground_seg: * Linearity: 0.530537
patchwork_ground_seg: * Planarity: 0.469274
patchwork_ground_seg: SizeOfRing: 430
patchwork_ground_seg: * Singular Values: 0.158036, 0.113088, 3.39509e-05
patchwork_ground_seg: * Linearity: 0.284418
patchwork_ground_seg: * Planarity: 0.715367
patchwork_ground_seg: SizeOfRing: 461
patchwork_ground_seg: * Singular Values: 0.163267, 0.104623, 4.05746e-05
patchwork_ground_seg: * Linearity: 0.359195
patchwork_ground_seg: * Planarity: 0.640557
patchwork_ground_seg: SizeOfRing: 527
patchwork_ground_seg: * Singular Values: 0.202164, 0.128592, 9.12833e-05
patchwork_ground_seg: * Linearity: 0.363922
patchwork_ground_seg: * Planarity: 0.635627
patchwork_ground_seg: SizeOfRing: 786
patchwork_ground_seg: * Singular Values: 0.356911, 0.116977, 8.66355e-05
patchwork_ground_seg: * Linearity: 0.672251
patchwork_ground_seg: * Planarity: 0.327506
patchwork_ground_seg: SizeOfRing: 843
patchwork_ground_seg: * Singular Values: 0.350674, 0.110203, 8.68107e-05
patchwork_ground_seg: * Linearity: 0.68574
patchwork_ground_seg: * Planarity: 0.314012
patchwork_ground_seg: SizeOfRing: 754
patchwork_ground_seg: * Singular Values: 0.237328, 0.132515, 5.75546e-05
patchwork_ground_seg: * Linearity: 0.441639
patchwork_ground_seg: * Planarity: 0.558119
patchwork_ground_seg: SizeOfRing: 558
patchwork_ground_seg: * Singular Values: 0.162093, 0.110739, 5.16564e-05
patchwork_ground_seg: * Linearity: 0.316819
patchwork_ground_seg: * Planarity: 0.682862
patchwork_ground_seg: SizeOfRing: 753
patchwork_ground_seg: * Singular Values: 0.167197, 0.103093, 0.00201635
patchwork_ground_seg: * Linearity: 0.383403
patchwork_ground_seg: * Planarity: 0.604537
patchwork_ground_seg: SizeOfRing: 795
patchwork_ground_seg: * Singular Values: 0.195423, 0.126148, 0.00168774
patchwork_ground_seg: * Linearity: 0.354488
patchwork_ground_seg: * Planarity: 0.636875
patchwork_ground_seg: SizeOfRing: 702
patchwork_ground_seg: * Singular Values: 0.35721, 0.123147, 0.00249468
patchwork_ground_seg: * Linearity: 0.655252
patchwork_ground_seg: * Planarity: 0.337764
patchwork_ground_seg: SizeOfRing: 511
patchwork_ground_seg: * Singular Values: 0.480244, 0.13327, 0.002766
patchwork_ground_seg: * Linearity: 0.722495
patchwork_ground_seg: * Planarity: 0.271745
patchwork_ground_seg: SizeOfRing: 187
patchwork_ground_seg: * Singular Values: 0.279308, 0.105251, 0.000206188
patchwork_ground_seg: * Linearity: 0.623173
patchwork_ground_seg: * Planarity: 0.376089
patchwork_ground_seg: SizeOfRing: 33
patchwork_ground_seg: * Singular Values: 0.0368877, 0.00435487, 1.95469e-05
patchwork_ground_seg: * Linearity: 0.881942
patchwork_ground_seg: * Planarity: 0.117528
patchwork_ground_seg: SizeOfRing: 0
patchwork_ground_seg: * Singular Values: 0.0368877, 0.00435487, 1.95469e-05
patchwork_ground_seg: * Linearity: 0.881942
patchwork_ground_seg: * Planarity: 0.117528
```

</details>


2. And here is the after the code change:
<details>

```
patchwork_ground_seg: SizeOfRing: 142
patchwork_ground_seg: * Singular Values: 0.110376, 0.0330322, 3.93967e-05
patchwork_ground_seg: * Linearity: 0.700729
patchwork_ground_seg: * Planarity: 0.298914
patchwork_ground_seg: SizeOfRing: 254
patchwork_ground_seg: * Singular Values: 0.233747, 0.106727, 3.83107e-05
patchwork_ground_seg: * Linearity: 0.54341
patchwork_ground_seg: * Planarity: 0.456426
patchwork_ground_seg: SizeOfRing: 288
patchwork_ground_seg: * Singular Values: 0.411811, 0.121756, 4.87517e-05
patchwork_ground_seg: * Linearity: 0.704341
patchwork_ground_seg: * Planarity: 0.295541
patchwork_ground_seg: SizeOfRing: 414
patchwork_ground_seg: * Singular Values: 0.443487, 0.123922, 4.69576e-05
patchwork_ground_seg: * Linearity: 0.720574
patchwork_ground_seg: * Planarity: 0.27932
patchwork_ground_seg: SizeOfRing: 497
patchwork_ground_seg: * Singular Values: 0.327631, 0.115926, 3.13969e-05
patchwork_ground_seg: * Linearity: 0.646168
patchwork_ground_seg: * Planarity: 0.353736
patchwork_ground_seg: SizeOfRing: 423
patchwork_ground_seg: * Singular Values: 0.16464, 0.100782, 2.70376e-05
patchwork_ground_seg: * Linearity: 0.387868
patchwork_ground_seg: * Planarity: 0.611967
patchwork_ground_seg: SizeOfRing: 422
patchwork_ground_seg: * Singular Values: 0.167495, 0.0648561, 3.43014e-05
patchwork_ground_seg: * Linearity: 0.612789
patchwork_ground_seg: * Planarity: 0.387007
patchwork_ground_seg: SizeOfRing: 487
patchwork_ground_seg: * Singular Values: 0.229241, 0.104464, 0.000121826
patchwork_ground_seg: * Linearity: 0.544303
patchwork_ground_seg: * Planarity: 0.455166
patchwork_ground_seg: SizeOfRing: 767
patchwork_ground_seg: * Singular Values: 0.36055, 0.138742, 9.2921e-05
patchwork_ground_seg: * Linearity: 0.615193
patchwork_ground_seg: * Planarity: 0.384549
patchwork_ground_seg: SizeOfRing: 852
patchwork_ground_seg: * Singular Values: 0.307547, 0.121315, 0.000131403
patchwork_ground_seg: * Linearity: 0.605542
patchwork_ground_seg: * Planarity: 0.394031
patchwork_ground_seg: SizeOfRing: 730
patchwork_ground_seg: * Singular Values: 0.198971, 0.129057, 6.5772e-05
patchwork_ground_seg: * Linearity: 0.351377
patchwork_ground_seg: * Planarity: 0.648292
patchwork_ground_seg: SizeOfRing: 529
patchwork_ground_seg: * Singular Values: 0.158642, 0.100017, 4.66582e-05
patchwork_ground_seg: * Linearity: 0.369541
patchwork_ground_seg: * Planarity: 0.630164
patchwork_ground_seg: SizeOfRing: 741
patchwork_ground_seg: * Singular Values: 0.16636, 0.103954, 0.00170705
patchwork_ground_seg: * Linearity: 0.375128
patchwork_ground_seg: * Planarity: 0.614611
patchwork_ground_seg: SizeOfRing: 804
patchwork_ground_seg: * Singular Values: 0.201368, 0.123692, 0.00174579
patchwork_ground_seg: * Linearity: 0.385743
patchwork_ground_seg: * Planarity: 0.605588
patchwork_ground_seg: SizeOfRing: 704
patchwork_ground_seg: * Singular Values: 0.360332, 0.119244, 0.00250925
patchwork_ground_seg: * Linearity: 0.669073
patchwork_ground_seg: * Planarity: 0.323963
patchwork_ground_seg: SizeOfRing: 507
patchwork_ground_seg: * Singular Values: 0.4803, 0.135758, 0.00307255
patchwork_ground_seg: * Linearity: 0.717348
patchwork_ground_seg: * Planarity: 0.276255
patchwork_ground_seg: SizeOfRing: 184
patchwork_ground_seg: * Singular Values: 0.278921, 0.10715, 0.000249198
patchwork_ground_seg: * Linearity: 0.615843
patchwork_ground_seg: * Planarity: 0.383264
patchwork_ground_seg: SizeOfRing: 30
patchwork_ground_seg: * Singular Values: 0.0474286, 0.00591493, 3.23724e-05
patchwork_ground_seg: * Linearity: 0.875288
patchwork_ground_seg: * Planarity: 0.12403


```

</details>


