### PR TITLE
Use incoming point cloud header for nodes with ROS subscriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,24 +2,21 @@ cmake_minimum_required(VERSION 3.0.2)
 project(patchwork)
 
 add_compile_options(-std=c++17)
-set(CMAKE_BUILD_TYPE "Release")
+# set(CMAKE_BUILD_TYPE "Release")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(catkin REQUIRED COMPONENTS
+        geometry_msgs
+        message_generation
+        pcl_conversions
+        pcl_ros
         roscpp
         rospy
         std_msgs
-        roslaunch
-        cv_bridge
-        pcl_conversions
-        pcl_ros
-        geometry_msgs
-        laser_geometry
         sensor_msgs
-        message_generation
         )
 
 add_message_files(
@@ -41,7 +38,7 @@ find_package(Boost 1.54 REQUIRED)
 catkin_package(
         INCLUDE_DIRS
         LIBRARIES
-        CATKIN_DEPENDS roscpp rospy std_msgs
+        CATKIN_DEPENDS geometry_msgs message_runtime roscpp rospy sensor_msgs std_msgs
 )
 
 option(USE_SYSTEM_TBB "Use system pre-installed oneAPI/tbb" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(patchwork)
 
 add_compile_options(-std=c++17)
-# set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_BUILD_TYPE "Release")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(patchwork)
 
 add_compile_options(-std=c++17)
-set(CMAKE_BUILD_TYPE "Release")
+# set(CMAKE_BUILD_TYPE "Release")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -11,7 +11,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(catkin REQUIRED COMPONENTS
         geometry_msgs
         message_generation
-        pcl_conversions
         pcl_ros
         roscpp
         rospy

--- a/nodes/offline_kitti.cpp
+++ b/nodes/offline_kitti.cpp
@@ -78,13 +78,6 @@ void pub_score(std::string mode, double measure) {
 }
 
 template<typename T>
-pcl::PointCloud<T> cloudmsg2cloud(sensor_msgs::PointCloud2 cloudmsg) {
-    pcl::PointCloud<T> cloudresult;
-    pcl::fromROSMsg(cloudmsg, cloudresult);
-    return cloudresult;
-}
-
-template<typename T>
 sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud, std::string frame_id ) {
     sensor_msgs::PointCloud2 cloud_ROS;
     pcl::toROSMsg(cloud, cloud_ROS);

--- a/nodes/offline_own_data.cpp
+++ b/nodes/offline_own_data.cpp
@@ -28,14 +28,6 @@ string      seq;
 bool        save_flag;
 
 template<typename T>
-pcl::PointCloud<T> cloudmsg2cloud(sensor_msgs::PointCloud2 cloudmsg)
-{
-    pcl::PointCloud<T> cloudresult;
-    pcl::fromROSMsg(cloudmsg,cloudresult);
-    return cloudresult;
-}
-
-template<typename T>
 sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud, std::string frame_id )
 {
     sensor_msgs::PointCloud2 cloud_ROS;

--- a/nodes/pub_for_legoloam.cpp
+++ b/nodes/pub_for_legoloam.cpp
@@ -58,8 +58,8 @@ void callbackNode(const sensor_msgs::PointCloud2::ConstPtr& msg) {
     PatchworkGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken);
 
 
-    auto msg_curr = cloud2msg(pc_curr, PatchworkGroundSeg->frame_patchwork);
-    auto msg_ground = cloud2msg(pc_ground, PatchworkGroundSeg->frame_patchwork);
+    auto msg_curr = cloud2msg(pc_curr);
+    auto msg_ground = cloud2msg(pc_ground);
 
     patchwork::ground_estimate cloud_estimate;
     cloud_estimate.header = msg->header;
@@ -68,9 +68,9 @@ void callbackNode(const sensor_msgs::PointCloud2::ConstPtr& msg) {
     EstimatePublisher.publish(cloud_estimate);
 
     /*
-    CloudPublisher.publish(cloud2msg(pc_curr, PatchworkGroundSeg->frame_patchwork));
-    PositivePublisher.publish(cloud2msg(pc_ground, PatchworkGroundSeg->frame_patchwork));
-    NegativePublisher.publish(cloud2msg(pc_non_ground, PatchworkGroundSeg->frame_patchwork));
+    CloudPublisher.publish(cloud2msg(pc_curr));
+    PositivePublisher.publish(cloud2msg(pc_ground));
+    NegativePublisher.publish(cloud2msg(pc_non_ground));
     */
 }
 

--- a/nodes/pub_for_legoloam.cpp
+++ b/nodes/pub_for_legoloam.cpp
@@ -37,11 +37,10 @@ pcl::PointCloud<T> cloudmsg2cloud(const sensor_msgs::PointCloud2::ConstPtr& clou
 }
 
 template<typename T>
-sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud, std::string frame_id )
+sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud)
 {
     sensor_msgs::PointCloud2 cloud_ROS;
     pcl::toROSMsg(cloud, cloud_ROS);
-    cloud_ROS.header.frame_id = frame_id;
     return cloud_ROS;
 }
 
@@ -50,6 +49,8 @@ void callbackNode(const sensor_msgs::PointCloud2::ConstPtr& msg) {
     pcl::PointCloud<PointType> pc_curr = cloudmsg2cloud<PointType>(msg);
     pcl::PointCloud<PointType> pc_ground;
     pcl::PointCloud<PointType> pc_non_ground;
+    pc_ground.header = pc_curr.header;
+    pc_non_ground.header = pc_curr.header;
 
     static double time_taken;
 

--- a/nodes/ros_kitti.cpp
+++ b/nodes/ros_kitti.cpp
@@ -2,6 +2,7 @@
 #define PCL_NO_PRECOMPILE
 #include <patchwork/node.h>
 #include "patchwork/patchwork.hpp"
+#include <pcl_conversions/pcl_conversions.h>
 #include <visualization_msgs/Marker.h>
 
 #include "tools/kitti_loader.hpp"
@@ -70,11 +71,10 @@ pcl::PointCloud<T> cloudmsg2cloud(sensor_msgs::PointCloud2 cloudmsg)
 }
 
 template<typename T>
-sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud, std::string frame_id )
+sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud)
 {
     sensor_msgs::PointCloud2 cloud_ROS;
     pcl::toROSMsg(cloud, cloud_ROS);
-    cloud_ROS.header.frame_id = frame_id;
     return cloud_ROS;
 }
 
@@ -83,6 +83,8 @@ void callbackNode(const sensor_msgs::PointCloud2::ConstPtr &msg) {
     pcl::PointCloud<PointType> pc_curr = cloudmsg2cloud<PointType>(*msg);
     pcl::PointCloud<PointType> pc_ground;
     pcl::PointCloud<PointType> pc_non_ground;
+    pc_ground.header = pc_curr.header;
+    pc_non_ground.header = pc_curr.header;
 
     static double time_taken;
 
@@ -111,6 +113,10 @@ void callbackNode(const sensor_msgs::PointCloud2::ConstPtr &msg) {
     pcl::PointCloud<PointType> FP;
     pcl::PointCloud<PointType> FN;
     pcl::PointCloud<PointType> TN;
+    TP.header = pc_curr.header;
+    FP.header = pc_curr.header;
+    FN.header = pc_curr.header;
+    TN.header = pc_curr.header;
 
     if (is_kitti) {
         discern_ground(pc_ground, TP, FP);
@@ -129,18 +135,18 @@ void callbackNode(const sensor_msgs::PointCloud2::ConstPtr &msg) {
         }
     }
 
-    CloudPublisher.publish(cloud2msg(pc_curr, PatchworkGroundSeg->frame_patchwork));
+    CloudPublisher.publish(cloud2msg(pc_curr));
     if (is_kitti) {
-        TPPublisher.publish(cloud2msg(TP, PatchworkGroundSeg->frame_patchwork));
-        FPPublisher.publish(cloud2msg(FP, PatchworkGroundSeg->frame_patchwork));
-        FNPublisher.publish(cloud2msg(FN, PatchworkGroundSeg->frame_patchwork));
+        TPPublisher.publish(cloud2msg(TP));
+        FPPublisher.publish(cloud2msg(FP));
+        FNPublisher.publish(cloud2msg(FN));
     } else {
         // Since other dataset has no labels,
         // so only estimated ground points / non-ground points are available
         if (GroundPublisher.getNumSubscribers())
-            GroundPublisher.publish(cloud2msg(pc_ground, PatchworkGroundSeg->frame_patchwork));
+            GroundPublisher.publish(cloud2msg(pc_ground));
         if (NonGroundPublisher.getNumSubscribers())
-            NonGroundPublisher.publish(cloud2msg(pc_non_ground, PatchworkGroundSeg->frame_patchwork));
+            NonGroundPublisher.publish(cloud2msg(pc_non_ground));
     }
     pub_score("p", precision);
     pub_score("r", recall);

--- a/nodes/ros_kitti.cpp
+++ b/nodes/ros_kitti.cpp
@@ -2,7 +2,6 @@
 #define PCL_NO_PRECOMPILE
 #include <patchwork/node.h>
 #include "patchwork/patchwork.hpp"
-#include <pcl_conversions/pcl_conversions.h>
 #include <visualization_msgs/Marker.h>
 
 #include "tools/kitti_loader.hpp"

--- a/package.xml
+++ b/package.xml
@@ -12,21 +12,18 @@
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <exec_depend>message_generation</exec_depend>
-  <exec_depend>libpcl-all</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>  
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>roslaunch</build_depend>
-  <build_depend>libpcl-all-dev</build_depend>
+  <depend>geometry_msgs</depend>
+  <depend>pcl_conversions</depend> 
+  <depend>pcl_ros</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>sensor_msgs</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>libpcl-all</exec_depend>
 
 
 

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,6 @@
   <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>geometry_msgs</depend>
-  <depend>pcl_conversions</depend> 
   <depend>pcl_ros</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
Hi,
Thanks for sharing this work.
I noticed when using it with online data, that in the header of the published point clouds the timestamp data was missing. This led me to slightly modify the code to copy the input cloud header for all outgoing messages.
I also changed and removed some dependencies and unused functions so that the compiler would stop complaining.